### PR TITLE
Use dbt_model_id to get the tested model node

### DIFF
--- a/macros/edr/data_monitoring/anomaly_detection/get_anomaly_scores_query.sql
+++ b/macros/edr/data_monitoring/anomaly_detection/get_anomaly_scores_query.sql
@@ -1,5 +1,5 @@
 {% macro get_anomaly_scores_query(test_metrics_table_relation, model_relation, test_configuration, monitors, dbt_model_id, column_name = none, columns_only = false, metric_properties = none, data_monitoring_metrics_table=none) %}
-    {%- set model_graph_node = elementary.get_model_graph_node(model_relation) %}
+    {%- set model_graph_node = elementary.get_model_graph_node(model_relation, dbt_model_id=dbt_model_id) %}
     {%- set full_table_name = elementary.model_node_to_full_name(model_graph_node) %}
     {%- set test_execution_id = elementary.get_test_execution_id() %}
     {%- set test_unique_id = elementary.get_test_unique_id() %}

--- a/macros/edr/tests/test_all_columns_anomalies.sql
+++ b/macros/edr/tests/test_all_columns_anomalies.sql
@@ -37,7 +37,8 @@
                                                                                                    detection_delay=detection_delay,
                                                                                                    anomaly_exclude_metrics=anomaly_exclude_metrics,
                                                                                                    detection_period=detection_period,
-                                                                                                   training_period=training_period) %}
+                                                                                                   training_period=training_period,
+                                                                                                   dbt_model_id=dbt_model_id) %}
 
         {%- if not test_configuration %}
             {{ exceptions.raise_compiler_error("Failed to create test configuration dict for test `{}`".format(test_table_name)) }}

--- a/macros/edr/tests/test_column_anomalies.sql
+++ b/macros/edr/tests/test_column_anomalies.sql
@@ -35,7 +35,8 @@
                                                                                                    detection_delay=detection_delay,
                                                                                                    anomaly_exclude_metrics=anomaly_exclude_metrics,
                                                                                                    detection_period=detection_period,
-                                                                                                   training_period=training_period) %}
+                                                                                                   training_period=training_period,
+                                                                                                   dbt_model_id=dbt_model_id) %}
 
         {%- if not test_configuration %}
             {{ exceptions.raise_compiler_error("Failed to create test configuration dict for test `{}`".format(test_table_name)) }}

--- a/macros/edr/tests/test_configuration/get_anomalies_test_configuration.sql
+++ b/macros/edr/tests/test_configuration/get_anomalies_test_configuration.sql
@@ -22,9 +22,10 @@
                                           detection_delay,
                                           anomaly_exclude_metrics,
                                           detection_period,
-                                          training_period) %}
+                                          training_period,
+                                          dbt_model_id=None) %}
 
-    {%- set model_graph_node = elementary.get_model_graph_node(model_relation) %}
+    {%- set model_graph_node = elementary.get_model_graph_node(model_relation, dbt_model_id=dbt_model_id) %}
 
     {# All anomaly detection tests #}
     {%- set timestamp_column = elementary.get_test_argument('timestamp_column', timestamp_column, model_graph_node) %}

--- a/macros/edr/tests/test_dimension_anomalies.sql
+++ b/macros/edr/tests/test_dimension_anomalies.sql
@@ -38,7 +38,8 @@
                                                                                                    detection_delay=detection_delay,
                                                                                                    anomaly_exclude_metrics=anomaly_exclude_metrics,
                                                                                                    detection_period=detection_period,
-                                                                                                   training_period=training_period) %}
+                                                                                                   training_period=training_period,
+                                                                                                   dbt_model_id=dbt_model_id) %}
         
         {%- if not test_configuration %}
             {{ exceptions.raise_compiler_error("Failed to create test configuration dict for test `{}`".format(test_table_name)) }}

--- a/macros/edr/tests/test_table_anomalies.sql
+++ b/macros/edr/tests/test_table_anomalies.sql
@@ -37,7 +37,8 @@
                                                                                                    detection_delay=detection_delay,
                                                                                                    anomaly_exclude_metrics=anomaly_exclude_metrics,
                                                                                                    detection_period=detection_period,
-                                                                                                   training_period=training_period) %}
+                                                                                                   training_period=training_period,
+                                                                                                   dbt_model_id=dbt_model_id) %}
 
         {% if not test_configuration %}
             {{ exceptions.raise_compiler_error("Failed to create test configuration dict for test `{}`".format(test_table_name)) }}

--- a/macros/edr/tests/test_utils/get_model_graph_node.sql
+++ b/macros/edr/tests/test_utils/get_model_graph_node.sql
@@ -6,7 +6,7 @@
         {# model relation is the relation object of the model where the test is defined #}
         {% set relation_name = model_relation.name | lower %}
 
-        {% if dbt_model_name %}
+        {% if dbt_model_id %}
             {% set relation_name = dbt_model_id.split('.')[2] %}
         {% endif %}
 

--- a/macros/edr/tests/test_utils/get_model_graph_node.sql
+++ b/macros/edr/tests/test_utils/get_model_graph_node.sql
@@ -1,10 +1,15 @@
-{% macro get_model_graph_node(model_relation) %}
+{% macro get_model_graph_node(model_relation, dbt_model_id=None) %}
     {% if execute %}
         {# model here is actually the test node in the graph #}
         {% set test_graph_node = model %}
         {% set test_depends_on_unique_ids = test_graph_node.depends_on.nodes %}
         {# model relation is the relation object of the model where the test is defined #}
         {% set relation_name = model_relation.name | lower %}
+
+        {% if dbt_model_name %}
+            {% set relation_name = dbt_model_id.split('.')[2] %}
+        {% endif %}
+
         {% set depends_on_nodes = elementary.get_nodes_by_unique_ids(test_depends_on_unique_ids) %}
         {% if depends_on_nodes %}
             {% for node in depends_on_nodes %}


### PR DESCRIPTION
It allows, for example, specify timestamp_column in the model config instead of passing it to each test as argument